### PR TITLE
Fixed the predicted value of difference in Probit

### DIFF
--- a/11-ch11.Rmd
+++ b/11-ch11.Rmd
@@ -296,7 +296,7 @@ predictions <- predict(denyprobit,
 diff(predictions)
 ```
 
-We find that an increase in the payment-to-income ratio from $0.3$ to $0.4$ is predicted to increase the probability of denial by approximately $6.2\%$.
+We find that an increase in the payment-to-income ratio from $0.3$ to $0.4$ is predicted to increase the probability of denial by approximately $6.1\%$.
 
 We continue by using an augmented Probit model to estimate the effect of race on the probability of a mortgage application denial.
 


### PR DESCRIPTION
The probit model predicted a difference of around 6.081% which rounds off to approximately 6.1% and not 6.2%. That has been fixed.